### PR TITLE
feat: add Telegram Sync plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -6487,5 +6487,13 @@
     "description": "Plugin to insert a specified symbol under the cursor",
     "author": "TakamiChie",
     "repo": "TakamiChie/Obsidian_CharacterInsertionPlugin"
+  },
+  {
+    "id": "obsidian-telegram-sync",
+    "name": "Telegram Sync",
+    "description": "Transfer messages and files from Telegram bot to Obsidian.",
+    "author": "soberHacker🍃🧘💻",
+    "repo": "soberhacker/obsidian-telegram-sync",
+    "branch": "main"
   }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin:  [obsidian-telegram-sync](https://github.com/soberhacker/obsidian-telegram-sync)

## Release Checklist
- [ x ] I have tested the plugin on
  - [ x ]  Windows
  - [ ]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [ ] My GitHub release contains all required files
  - [ x ] `main.js`
  - [ x ] `manifest.json`
  - [ x ] `styles.css` _(optional)_
- [ x ] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [ x ] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [ x ] My README.md describes the plugin's purpose and provides clear usage instructions.
- [ x ] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [ x ] I have added a license in the LICENSE file.
- [ x ] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
